### PR TITLE
chore: migrate npm registry from CodeArtifact to JFrog

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 always-auth=true
-registry=https://appfolio-ecr-195334327833.d.codeartifact.us-west-2.amazonaws.com/npm/appfolio-repo/
-//appfolio-ecr-195334327833.d.codeartifact.us-west-2.amazonaws.com/npm/appfolio-repo/:_authToken=${CODEARTIFACT_AUTH_TOKEN}
+registry=https://appfolio.jfrog.io/artifactory/api/npm/appfolio-alexander_graham_bell-npm/
+//appfolio.jfrog.io/artifactory/api/npm/appfolio-alexander_graham_bell-npm/:_authToken=${JFROG_ACCESS_TOKEN}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-npmRegistryServer: https://appfolio-ecr-195334327833.d.codeartifact.us-west-2.amazonaws.com/npm/appfolio-repo/
+npmRegistryServer: https://appfolio.jfrog.io/artifactory/api/npm/appfolio-alexander_graham_bell-npm/
 npmAlwaysAuth: true
 enableTelemetry: false
-npmAuthToken: ${CODEARTIFACT_AUTH_TOKEN}
+npmAuthToken: ${JFROG_ACCESS_TOKEN}


### PR DESCRIPTION
## Summary

FEE-1627

Migrates this repo's npm registry configuration from AWS CodeArtifact to JFrog Artifactory as part of the org-wide rollout.

**Changes:**
- Registry config files (`.yarnrc.yml` / `.npmrc`): URL → JFrog, token → `JFROG_ACCESS_TOKEN`
- CircleCI: replaces CodeArtifact commands with `public-packages/setup` orb step
- GitHub Actions: replaces `appfolio/generate-codeartifact-token` with `appfolio/public-packages/setup@v1`
- Dockerfiles: secret mount IDs and env vars updated
- Docs: updates CodeArtifact references to JFrog

**No action needed on your end** — just review and merge. If CI is red or you have questions, ping #jfrog-support.

## Local setup

Run `otto login --install-jfrog-token` to get a local `JFROG_ACCESS_TOKEN` (lasts 1 year).
